### PR TITLE
Punycode code improvements

### DIFF
--- a/src/Punycode.php
+++ b/src/Punycode.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace True;
 
 /**
@@ -8,11 +9,10 @@ namespace True;
  */
 class Punycode
 {
-
-/**
- * Bootstring parameter values
- *
- */
+    /**
+     * Bootstring parameter values
+     *
+     */
     const BASE         = 36;
     const TMIN         = 1;
     const TMAX         = 26;
@@ -23,55 +23,55 @@ class Punycode
     const PREFIX       = 'xn--';
     const DELIMITER    = '-';
 
-/**
- * Encode table
- *
- * @param array
- */
-    protected static $_encodeTable = array(
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
-        'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
-        'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    /**
+     * Encode table
+     *
+     * @param array
+     */
+    protected static $transcodeTable = array(
+        'a', 'b', 'c', 'd', 'e', 'f',
+        'g', 'h', 'i', 'j', 'k', 'l',
+        'm', 'n', 'o', 'p', 'q', 'r',
+        's', 't', 'u', 'v', 'w', 'x',
+        'y', 'z', '0', '1', '2', '3',
+        '4', '5', '6', '7', '8', '9',
     );
 
-/**
- * Decode table
- *
- * @param array
- */
-    protected static $_decodeTable = array(
-        'a' =>  0, 'b' =>  1, 'c' =>  2, 'd' =>  3, 'e' =>  4, 'f' =>  5,
-        'g' =>  6, 'h' =>  7, 'i' =>  8, 'j' =>  9, 'k' => 10, 'l' => 11,
-        'm' => 12, 'n' => 13, 'o' => 14, 'p' => 15, 'q' => 16, 'r' => 17,
-        's' => 18, 't' => 19, 'u' => 20, 'v' => 21, 'w' => 22, 'x' => 23,
-        'y' => 24, 'z' => 25, '0' => 26, '1' => 27, '2' => 28, '3' => 29,
-        '4' => 30, '5' => 31, '6' => 32, '7' => 33, '8' => 34, '9' => 35
-    );
-
-/**
- * Encode a domain to its Punycode version
- *
- * @param string $input Domain name in Unicde to be encoded
- * @return string Punycode representation in ASCII
- */
+    /**
+     * Encode a hostname using the punycode algorythm
+     *
+     * @param string $input Domain name in Unicde to be encoded
+     *
+     * @return string Punycode representation in ASCII
+     */
     public function encode($input)
     {
+        $input = (string) $input;
+        $input = trim($input);
         $parts = explode('.', $input);
         foreach ($parts as &$part) {
-            $part = $this->_encodePart($part);
+            $part = $this->punycodeEncode($part);
         }
+        unset($part);
+
         return implode('.', $parts);
     }
 
-/**
- * Encode a part of a domain name, such as tld, to its Punycode version
- *
- * @param string $input Part of a domain name
- * @return string Punycode representation of a domain part
- */
-    protected function _encodePart($input)
+    /**
+     * Encode a string using the punycode algorythm
+     *
+     * @param string $input string
+     *
+     * @return string
+     */
+    public function punycodeEncode($input)
     {
-        $codePoints = $this->_codePoints($input);
+        $encoding = mb_internal_encoding();
+        if (stripos($encoding, 'utf-8') === false) {
+            mb_internal_encoding('utf-8');
+        }
+
+        $codePoints = $this->getCodePoints($input);
 
         $n = static::INITIAL_N;
         $bias = static::INITIAL_BIAS;
@@ -80,17 +80,16 @@ class Punycode
 
         $output = '';
         foreach ($codePoints['basic'] as $code) {
-            $output .= $this->_codePointToChar($code);
+            $output .= $this->codepointToChar($code);
         }
         if ($input === $output) {
+             mb_internal_encoding($encoding);
+
             return $output;
         }
         if ($b > 0) {
             $output .= static::DELIMITER;
         }
-
-        $codePoints['nonBasic'] = array_unique($codePoints['nonBasic']);
-        sort($codePoints['nonBasic']);
 
         $i = 0;
         $length = mb_strlen($input);
@@ -118,13 +117,13 @@ class Punycode
                         }
 
                         $code = $t + (($q - $t) % (static::BASE - $t));
-                        $output .= static::$_encodeTable[$code];
+                        $output .= static::$transcodeTable[$code];
 
                         $q = ($q - $t) / (static::BASE - $t);
                     }
 
-                    $output .= static::$_encodeTable[$q];
-                    $bias = $this->_adapt($delta, $h + 1, ($h === $b));
+                    $output .= static::$transcodeTable[$q];
+                    $bias = $this->adapt($delta, $h + 1, ($h === $b));
                     $delta = 0;
                     $h++;
                 }
@@ -133,37 +132,49 @@ class Punycode
             $delta++;
             $n++;
         }
+        mb_internal_encoding($encoding);
 
         return static::PREFIX . $output;
     }
 
-/**
- * Decode a Punycode domain name to its Unicode counterpart
- *
- * @param string $input Domain name in Punycode
- * @return string Unicode domain name
- */
+    /**
+     * Decode an hostname encoded using the punycode algorythm
+     *
+     * @param string $input hostname in Punycode
+     *
+     * @return string Unicode domain name
+     */
     public function decode($input)
     {
+        $input = (string) $input;
+        $input = trim($input);
         $parts = explode('.', $input);
         foreach ($parts as &$part) {
-            $part = $this->_decodePart($part);
+            $part = $this->punycodeDecode($part);
         }
+        unset($part);
+
         return implode('.', $parts);
     }
 
-/**
- * Decode a part of domain name, such as tld
- *
- * @param string $input Part of a domain name
- * @return string Unicode domain part
- */
-    protected function _decodePart($input)
+    /**
+     * Decode a string encoded using the punycode algorythm
+     *
+     * @param string $input encoded string using punycode
+     *
+     * @return string
+     */
+    public function punycodeDecode($input)
     {
         if (strpos($input, static::PREFIX) !== 0) {
             return $input;
         }
         $input = ltrim($input, static::PREFIX);
+
+        $encoding = mb_internal_encoding();
+        if (stripos($encoding, 'utf-8') === false) {
+            mb_internal_encoding('utf-8');
+        }
 
         $n = static::INITIAL_N;
         $i = 0;
@@ -179,12 +190,13 @@ class Punycode
 
         $outputLength = strlen($output);
         $inputLength = strlen($input);
+        $decodeTable = array_flip(static::$transcodeTable);
         while ($pos < $inputLength) {
             $oldi = $i;
             $w = 1;
 
             for ($k = static::BASE;; $k += static::BASE) {
-                $digit = static::$_decodeTable[$input[$pos++]];
+                $digit = $decodeTable[$input[$pos++]];
                 $i = $i + ($digit * $w);
 
                 if ($k <= $bias + static::TMIN) {
@@ -201,51 +213,52 @@ class Punycode
                 $w = $w * (static::BASE - $t);
             }
 
-            $bias = $this->_adapt($i - $oldi, ++$outputLength, ($oldi === 0));
-            $n = $n + (int)($i / $outputLength);
+            $bias = $this->adapt($i - $oldi, ++$outputLength, ($oldi === 0));
+            $n = $n + (int) ($i / $outputLength);
             $i = $i % ($outputLength);
-            $output = mb_substr($output, 0, $i) . $this->_codePointToChar($n) . mb_substr($output, $i, $outputLength - 1);
+            $output = mb_substr($output, 0, $i)
+                .$this->codepointToChar($n)
+                .mb_substr($output, $i, $outputLength - 1);
 
             $i++;
         }
 
+        mb_internal_encoding($encoding);
+
         return $output;
     }
 
-/**
- * Bias adaptation
- *
- * @param integer $delta
- * @param integer $numPoints
- * @param boolean $firstTime
- * @return integer
- */
-    protected function _adapt($delta, $numPoints, $firstTime)
+    /**
+     * Bias adaptation function as per section 3.4 of RFC 3492.
+     *
+     * @param float   $delta
+     * @param integer $num_points
+     * @param boolean $first_time
+     *
+     * @return integer
+     */
+    protected function adapt($delta, $num_points, $first_time)
     {
-        $delta = (int)(
-            ($firstTime)
-                ? $delta / static::DAMP
-                : $delta / 2
-            );
-        $delta += (int)($delta / $numPoints);
+        $key = 0;
+        $delta = $first_time ? floor($delta / static::DAMP) : $delta >> 1;
+        $delta += floor($delta / $num_points);
 
-        $k = 0;
-        while ($delta > ((static::BASE - static::TMIN) * static::TMAX) / 2) {
-            $delta = (int)($delta / (static::BASE - static::TMIN));
-            $k = $k + static::BASE;
+        $tmp = static::BASE - static::TMIN;
+        for (; $delta > $tmp * static::TMAX >> 1; $key += static::BASE) {
+            $delta = floor($delta / $tmp);
         }
-        $k = $k + (int)(((static::BASE - static::TMIN + 1) * $delta) / ($delta + static::SKEW));
 
-        return $k;
+        return floor($key + ($tmp + 1) * $delta / ($delta + static::SKEW));
     }
 
-/**
- * List code points for a given input
- *
- * @param string $input
- * @return array Multi-dimension array with basic, non-basic and aggregated code points
- */
-    protected function _codePoints($input)
+    /**
+     * List code points for a given input
+     *
+     * @param string $input
+     *
+     * @return array Multi-dimension array with basic, non-basic and aggregated code points
+     */
+    protected function getCodePoints($input)
     {
         $codePoints = array(
             'all'      => array(),
@@ -256,24 +269,29 @@ class Punycode
         $length = mb_strlen($input);
         for ($i = 0; $i < $length; $i++) {
             $char = mb_substr($input, $i, 1);
-            $code = $this->_charToCodePoint($char);
+            $code = static::charToCodepoint($char);
+            $codePoints['all'][] = $code;
+            $offset = 'nonBasic';
             if ($code < 128) {
-                $codePoints['all'][] = $codePoints['basic'][] = $code;
-            } else {
-                $codePoints['all'][] = $codePoints['nonBasic'][] = $code;
+                $offset = 'basic';
             }
+            $codePoints[$offset][] = $code;
         }
+
+        $codePoints['nonBasic'] = array_unique($codePoints['nonBasic']);
+        sort($codePoints['nonBasic']);
 
         return $codePoints;
     }
 
-/**
- * Convert a single or multi-byte character to its code point
- *
- * @param string $char
- * @return integer
- */
-    protected function _charToCodePoint($char)
+    /**
+     * Convert a single or multi-byte character to its codepoint
+     *
+     * @param string $char
+     *
+     * @return integer
+     */
+    protected function charToCodepoint($char)
     {
         $code = ord($char[0]);
         if ($code < 128) {
@@ -282,18 +300,22 @@ class Punycode
             return (($code - 192) * 64) + (ord($char[1]) - 128);
         } elseif ($code < 240) {
             return (($code - 224) * 4096) + ((ord($char[1]) - 128) * 64) + (ord($char[2]) - 128);
-        } else {
-            return (($code - 240) * 262144) + ((ord($char[1]) - 128) * 4096) + ((ord($char[2]) - 128) * 64) + (ord($char[3]) - 128);
         }
+
+        return (($code - 240) * 262144)
+            + ((ord($char[1]) - 128) * 4096)
+            + ((ord($char[2]) - 128) * 64)
+            + (ord($char[3]) - 128);
     }
 
-/**
- * Convert a code point to its single or multi-byte character
- *
- * @param integer $code
- * @return string
- */
-    protected function _codePointToChar($code)
+    /**
+     * Convert a codepoint to its single or multi-byte character
+     *
+     * @param integer $code
+     *
+     * @return string
+     */
+    protected function codepointToChar($code)
     {
         if ($code <= 0x7F) {
             return chr($code);
@@ -301,8 +323,11 @@ class Punycode
             return chr(($code >> 6) + 192) . chr(($code & 63) + 128);
         } elseif ($code <= 0xFFFF) {
             return chr(($code >> 12) + 224) . chr((($code >> 6) & 63) + 128) . chr(($code & 63) + 128);
-        } else {
-            return chr(($code >> 18) + 240) . chr((($code >> 12) & 63) + 128) . chr((($code >> 6) & 63) + 128) . chr(($code & 63) + 128);
         }
+
+        return chr(($code >> 18) + 240)
+            .chr((($code >> 12) & 63) + 128)
+            .chr((($code >> 6) & 63) + 128)
+            .chr(($code & 63) + 128);
     }
 }

--- a/tests/PunycodeTest.php
+++ b/tests/PunycodeTest.php
@@ -1,55 +1,42 @@
 <?php
+
 namespace True;
 
-use True\Punycode;
+use PHPUnit_Framework_TestCase;
 
-class PunycodeTest extends \PHPUnit_Framework_TestCase
+class PunycodeTest extends PHPUnit_Framework_TestCase
 {
-
-/**
- * Make sure the right internal encoding is defined when testing
- *
- */
-    public function setUp()
-    {
-        parent::setUp();
-
-        mb_internal_encoding('utf-8');
-    }
-
-/**
- * Test encoding Punycode
- *
- * @param string $decoded Decoded domain
- * @param string $encoded Encoded domain
- * @dataProvider domainNamesProvider
- */
+    /**
+     * Test encoding Punycode
+     *
+     * @param string $decoded Decoded domain
+     * @param string $encoded Encoded domain
+     * @dataProvider domainNamesProvider
+     */
     public function testEncode($decoded, $encoded)
     {
-        $Punycode = new Punycode();
-        $result = $Punycode->encode($decoded);
-        $this->assertEquals($encoded, $result);
+        $punycode = new Punycode;
+        $this->assertSame($encoded, $punycode->encode($decoded));
     }
 
-/**
- * Test decoding Punycode
- *
- * @param string $decoded Decoded domain
- * @param string $encoded Encoded domain
- * @dataProvider domainNamesProvider
- */
+    /**
+     * Test decoding Punycode
+     *
+     * @param string $decoded Decoded domain
+     * @param string $encoded Encoded domain
+     * @dataProvider domainNamesProvider
+     */
     public function testDecode($decoded, $encoded)
     {
-        $Punycode = new Punycode();
-        $result = $Punycode->decode($encoded);
-        $this->assertEquals($decoded, $result);
+        $punycode = new Punycode;
+        $this->assertSame($decoded, $punycode->decode($encoded));
     }
 
-/**
- * Provide domain names containing the decoded and encoded names
- *
- * @return array
- */
+    /**
+     * Provide domain names containing the decoded and encoded names
+     *
+     * @return array
+     */
     public function domainNamesProvider()
     {
         return array(


### PR DESCRIPTION
* `Punycode::encodePart` is renamed `Punycode::punycodeEncode` and is now public
* `Punycode::decodePart` is renamed `Punycode::punycodeDecode` and is now public
* the  `mb_internal_encoding` is directly set into `Punycode::punycodeEncode`  and `Punycode::punycodeDecode`  so we don't need to set them in the script.
* internal code improvement:
    * `Punycode::$decodeTable` is removed
    * `Punycode::$encodeTable` is renamed `Pynycode::$transcodeTable` 
    * `Punycode::adapt` rewrote