### PR TITLE
Improve Punycode Encoding/Decoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"ext-mbstring": "*"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "4.x",
+		"phpunit/phpunit": "~4.0",
 		"satooshi/php-coveralls": "dev-master",
 		"squizlabs/php_codesniffer": "~2.0"
 	}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,33 @@
-<?xml version="1.0"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true" verbose="true">
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+
     <testsuites>
-        <testsuite name="Punycode Test Suite">
-            <directory>tests/</directory>
+        <testsuite name="Php Punycode Test Suite">
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
+
     <filter>
         <whitelist>
-            <directory suffix=".php">src/</directory>
+            <directory suffix=".php">src</directory>
         </whitelist>
-        <blacklist>
-            <directory>tests</directory>
-            <directory>vendor</directory>
-        </blacklist>
     </filter>
+
     <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/clover.xml"/>
     </logging>
 </phpunit>

--- a/src/Punycode.php
+++ b/src/Punycode.php
@@ -8,10 +8,8 @@ namespace TrueBV;
  */
 class Punycode
 {
-
     /**
-     * Bootstring parameter values
-     *
+     * Bootstring parameter values for host punycode
      */
     const BASE         = 36;
     const TMIN         = 1;
@@ -28,10 +26,13 @@ class Punycode
      *
      * @param array
      */
-    protected static $_encodeTable = array(
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
-        'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x',
-        'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    protected static $encodeTable = array(
+        0  => 'a', 1  => 'b', 2  => 'c', 3  => 'd', 4  => 'e', 5  => 'f',
+        6  => 'g', 7  => 'h', 8  => 'i', 9  => 'j', 10 => 'k', 11 => 'l',
+        12 => 'm', 13 => 'n', 14 => 'o', 15 => 'p', 16 => 'q', 17 => 'r',
+        18 => 's', 19 => 't', 20 => 'u', 21 => 'v', 22 => 'w', 23 => 'x',
+        24 => 'y', 25 => 'z', 26 =>   0, 27 =>   1, 28 =>   2, 29 =>   3,
+        30 =>   4, 31 =>   5, 32 =>   6, 33 =>   7, 34 =>   8, 35 =>   9,
     );
 
     /**
@@ -39,13 +40,13 @@ class Punycode
      *
      * @param array
      */
-    protected static $_decodeTable = array(
-        'a' =>  0, 'b' =>  1, 'c' =>  2, 'd' =>  3, 'e' =>  4, 'f' =>  5,
+    protected static $decodeTable = array(
+        'a' =>  0, 'b' =>  1, 'c' =>  2, 'd' =>  3, 'e' =>  4, 'f' => 5,
         'g' =>  6, 'h' =>  7, 'i' =>  8, 'j' =>  9, 'k' => 10, 'l' => 11,
         'm' => 12, 'n' => 13, 'o' => 14, 'p' => 15, 'q' => 16, 'r' => 17,
         's' => 18, 't' => 19, 'u' => 20, 'v' => 21, 'w' => 22, 'x' => 23,
-        'y' => 24, 'z' => 25, '0' => 26, '1' => 27, '2' => 28, '3' => 29,
-        '4' => 30, '5' => 31, '6' => 32, '7' => 33, '8' => 34, '9' => 35
+        'y' => 24, 'z' => 25,   0 => 26,   1 => 27,   2 => 28,   3 => 29,
+          4 => 30,   5 => 31,   6 => 32,   7 => 33,   8 => 34,   9 => 35,
     );
 
     /**
@@ -66,227 +67,89 @@ class Punycode
     }
 
     /**
-     * Encode a domain to its Punycode version
-     *
-     * @param string $input Domain name in Unicde to be encoded
-     * @return string Punycode representation in ASCII
-     */
-    public function encode($input)
-    {
-        $parts = explode('.', $input);
-        foreach ($parts as &$part) {
-            $part = $this->_encodePart($part);
-        }
-
-        return implode('.', $parts);
-    }
-
-    /**
      * Encode a part of a domain name, such as tld, to its Punycode version
      *
      * @param string $input Part of a domain name
+     *
      * @return string Punycode representation of a domain part
      */
-    protected function _encodePart($input)
+    public function encode($input)
     {
-        $codePoints = $this->_codePoints($input);
-
-        $n = static::INITIAL_N;
-        $bias = static::INITIAL_BIAS;
-        $delta = 0;
-        $h = $b = count($codePoints['basic']);
-
-        $output = '';
-        foreach ($codePoints['basic'] as $code) {
-            $output .= $this->_codePointToChar($code);
-        }
-        if ($input === $output) {
-            return $output;
-        }
-        if ($b > 0) {
-            $output .= static::DELIMITER;
-        }
-
-        $codePoints['nonBasic'] = array_unique($codePoints['nonBasic']);
-        sort($codePoints['nonBasic']);
-
-        $i = 0;
-        $length = mb_strlen($input, $this->encoding);
-        while ($h < $length) {
-            $m = $codePoints['nonBasic'][$i++];
-            $delta = $delta + ($m - $n) * ($h + 1);
-            $n = $m;
-
-            foreach ($codePoints['all'] as $c) {
-                if ($c < $n || $c < static::INITIAL_N) {
-                    $delta++;
-                }
-                if ($c === $n) {
-                    $q = $delta;
-                    for ($k = static::BASE;; $k += static::BASE) {
-                        $t = $this->_calculateThreshold($k, $bias);
-                        if ($q < $t) {
-                            break;
-                        }
-
-                        $code = $t + (($q - $t) % (static::BASE - $t));
-                        $output .= static::$_encodeTable[$code];
-
-                        $q = ($q - $t) / (static::BASE - $t);
-                    }
-
-                    $output .= static::$_encodeTable[$q];
-                    $bias = $this->_adapt($delta, $h + 1, ($h === $b));
-                    $delta = 0;
-                    $h++;
-                }
-            }
-
-            $delta++;
-            $n++;
-        }
-
-        return static::PREFIX . $output;
+        return implode('.', array_map(array($this, 'encodeLabel'), explode('.', $input)));
     }
 
     /**
      * Decode a Punycode domain name to its Unicode counterpart
      *
      * @param string $input Domain name in Punycode
+     *
      * @return string Unicode domain name
      */
     public function decode($input)
     {
-        $parts = explode('.', $input);
-        foreach ($parts as &$part) {
-            if (strpos($part, static::PREFIX) !== 0) {
-                continue;
-            }
-
-            $part = substr($part, strlen(static::PREFIX));
-            $part = $this->_decodePart($part);
-        }
-
-        return implode('.', $parts);
+        return implode('.', array_map(array($this, 'decodeLabel'), explode('.', $input)));
     }
 
     /**
-     * Decode a part of domain name, such as tld
+     * Encode a hostname label to its Punycode version
      *
-     * @param string $input Part of a domain name
-     * @return string Unicode domain part
+     * @param string $input hostname label
+     *
+     * @return string hostname label punycode representation
      */
-    protected function _decodePart($input)
+    public function encodeLabel($input)
     {
-        $n = static::INITIAL_N;
-        $i = 0;
-        $bias = static::INITIAL_BIAS;
-        $output = '';
-
-        $pos = strrpos($input, static::DELIMITER);
-        if ($pos !== false) {
-            $output = substr($input, 0, $pos++);
-        } else {
-            $pos = 0;
+        $codePoints = $this->codePoints($input);
+        if (empty($codePoints['nonBasic'])) {
+            return $input;
         }
 
-        $outputLength = strlen($output);
-        $inputLength = strlen($input);
-        while ($pos < $inputLength) {
-            $oldi = $i;
-            $w = 1;
-
-            for ($k = static::BASE;; $k += static::BASE) {
-                $digit = static::$_decodeTable[$input[$pos++]];
-                $i = $i + ($digit * $w);
-                $t = $this->_calculateThreshold($k, $bias);
-
-                if ($digit < $t) {
-                    break;
-                }
-
-                $w = $w * (static::BASE - $t);
-            }
-
-            $bias = $this->_adapt($i - $oldi, ++$outputLength, ($oldi === 0));
-            $n = $n + (int) ($i / $outputLength);
-            $i = $i % ($outputLength);
-            $output = mb_substr($output, 0, $i, $this->encoding) . $this->_codePointToChar($n) . mb_substr($output, $i, $outputLength - 1, $this->encoding);
-
-            $i++;
-        }
-
-        return $output;
+        return $this->encodeString($codePoints, $input);
     }
 
     /**
-     * Calculate the bias threshold to fall between TMIN and TMAX
+     * Return a punycoded host label into its unicode representation
      *
-     * @param integer $k
-     * @param integer $bias
-     * @return integer
-     */
-    protected function _calculateThreshold($k, $bias)
-    {
-        if ($k <= $bias + static::TMIN) {
-            return static::TMIN;
-        } elseif ($k >= $bias + static::TMAX) {
-            return static::TMAX;
-        }
-        return $k - $bias;
-    }
-
-    /**
-     * Bias adaptation
+     * @param  string $input
      *
-     * @param integer $delta
-     * @param integer $numPoints
-     * @param boolean $firstTime
-     * @return integer
+     * @return string
      */
-    protected function _adapt($delta, $numPoints, $firstTime)
+    public function decodeLabel($input)
     {
-        $delta = (int) (
-            ($firstTime)
-                ? $delta / static::DAMP
-                : $delta / 2
-            );
-        $delta += (int) ($delta / $numPoints);
-
-        $k = 0;
-        while ($delta > ((static::BASE - static::TMIN) * static::TMAX) / 2) {
-            $delta = (int) ($delta / (static::BASE - static::TMIN));
-            $k = $k + static::BASE;
+        if (strpos($input, static::PREFIX) !== 0) {
+            return $input;
         }
-        $k = $k + (int) (((static::BASE - static::TMIN + 1) * $delta) / ($delta + static::SKEW));
 
-        return $k;
+        $codePoints = $this->codePoints($input);
+        $rawLabel   = substr($input, strlen(static::PREFIX));
+        if (!empty($codePoints["nonBasic"]) || !($decoded = $this->decodeString($rawLabel))) {
+            return $input;
+        }
+
+        return $decoded;
     }
 
     /**
      * List code points for a given input
      *
      * @param string $input
+     *
      * @return array Multi-dimension array with basic, non-basic and aggregated code points
      */
-    protected function _codePoints($input)
+    protected function codePoints($input)
     {
-        $codePoints = array(
-            'all'      => array(),
-            'basic'    => array(),
-            'nonBasic' => array(),
+        $codePoints = array('all' => array(), 'basic' => array(), 'nonBasic' => array());
+        $codePoints['all'] = array_map(
+            [$this, 'charToCodePoint'],
+            preg_split("//u", $input, -1, PREG_SPLIT_NO_EMPTY)
         );
 
-        $length = mb_strlen($input, $this->encoding);
-        for ($i = 0; $i < $length; $i++) {
-            $char = mb_substr($input, $i, 1, $this->encoding);
-            $code = $this->_charToCodePoint($char);
-            if ($code < 128) {
-                $codePoints['all'][] = $codePoints['basic'][] = $code;
-            } else {
-                $codePoints['all'][] = $codePoints['nonBasic'][] = $code;
-            }
+        foreach ($codePoints['all'] as $code) {
+            $codePoints[($code < 128) ? 'basic' : 'nonBasic'][] = $code;
         }
+
+        $codePoints['nonBasic'] = array_unique($codePoints['nonBasic']);
+        sort($codePoints['nonBasic']);
 
         return $codePoints;
     }
@@ -295,38 +158,194 @@ class Punycode
      * Convert a single or multi-byte character to its code point
      *
      * @param string $char
-     * @return integer
+     *
+     * @return int
      */
-    protected function _charToCodePoint($char)
+    protected function charToCodePoint($char)
     {
         $code = ord($char[0]);
         if ($code < 128) {
             return $code;
-        } elseif ($code < 224) {
-            return (($code - 192) * 64) + (ord($char[1]) - 128);
-        } elseif ($code < 240) {
-            return (($code - 224) * 4096) + ((ord($char[1]) - 128) * 64) + (ord($char[2]) - 128);
-        } else {
-            return (($code - 240) * 262144) + ((ord($char[1]) - 128) * 4096) + ((ord($char[2]) - 128) * 64) + (ord($char[3]) - 128);
         }
+
+        if ($code < 224) {
+            return (($code - 192) * 64) + (ord($char[1]) - 128);
+        }
+
+        if ($code < 240) {
+            return (($code - 224) * 4096) + ((ord($char[1]) - 128) * 64) + (ord($char[2]) - 128);
+        }
+
+        return (($code - 240) * 262144) + ((ord($char[1]) - 128) * 4096)
+            + ((ord($char[2]) - 128) * 64) + (ord($char[3]) - 128);
+    }
+
+    /**
+     * Encode a string into its punycode version
+     *
+     * @param  array  $codePoints input code points
+     * @param  string $input      input string
+     *
+     * @return string
+     */
+    protected function encodeString(array $codePoints, $input)
+    {
+        $n      = static::INITIAL_N;
+        $bias   = static::INITIAL_BIAS;
+        $delta  = 0;
+        $h      = count($codePoints['basic']);
+        $b      = $h;
+        $i      = 0;
+        $length = mb_strlen($input, $this->encoding);
+        $output = array_map(array($this, 'codePointToChar'), $codePoints['basic']);
+        if ($b > 0) {
+            $output[] = static::DELIMITER;
+        }
+        while ($h < $length) {
+            $m     = $codePoints['nonBasic'][$i++];
+            $delta = $delta + ($m - $n) * ($h + 1);
+            $n     = $m;
+            foreach ($codePoints['all'] as $c) {
+                if ($c < $n || $c < static::INITIAL_N) {
+                    ++$delta;
+                }
+                if ($c === $n) {
+                    $q = $delta;
+                    for ($k = static::BASE;; $k += static::BASE) {
+                        $t = $this->calculateThreshold($k, $bias);
+                        if ($q < $t) {
+                            break;
+                        }
+                        $code     = $t + (($q - $t) % (static::BASE - $t));
+                        $output[] = static::$encodeTable[$code];
+                        $q        = ($q - $t) / (static::BASE - $t);
+                    }
+                    $output[] = static::$encodeTable[$q];
+                    $bias     = $this->adapt($delta, $h + 1, $h === $b);
+                    $delta    = 0;
+                    $h++;
+                }
+            }
+            ++$delta;
+            ++$n;
+        }
+
+        return static::PREFIX.implode('', $output);
     }
 
     /**
      * Convert a code point to its single or multi-byte character
      *
-     * @param integer $code
+     * @param int $code
+     *
      * @return string
      */
-    protected function _codePointToChar($code)
+    protected function codePointToChar($code)
     {
         if ($code <= 0x7F) {
             return chr($code);
-        } elseif ($code <= 0x7FF) {
-            return chr(($code >> 6) + 192) . chr(($code & 63) + 128);
-        } elseif ($code <= 0xFFFF) {
-            return chr(($code >> 12) + 224) . chr((($code >> 6) & 63) + 128) . chr(($code & 63) + 128);
-        } else {
-            return chr(($code >> 18) + 240) . chr((($code >> 12) & 63) + 128) . chr((($code >> 6) & 63) + 128) . chr(($code & 63) + 128);
         }
+
+        if ($code <= 0x7FF) {
+            return chr(($code >> 6) + 192).chr(($code & 63) + 128);
+        }
+
+        if ($code <= 0xFFFF) {
+            return chr(($code >> 12) + 224).chr((($code >> 6) & 63) + 128).chr(($code & 63) + 128);
+        }
+
+        return chr(($code >> 18) + 240).chr((($code >> 12) & 63) + 128)
+            .chr((($code >> 6) & 63) + 128).chr(($code & 63) + 128);
+    }
+
+    /**
+     * Calculate the bias threshold to fall between TMIN and TMAX
+     *
+     * @param int $k
+     * @param int $bias
+     *
+     * @return int
+     */
+    protected function calculateThreshold($k, $bias)
+    {
+        if ($k <= $bias + static::TMIN) {
+            return static::TMIN;
+        }
+
+        if ($k >= $bias + static::TMAX) {
+            return static::TMAX;
+        }
+
+        return $k - $bias;
+    }
+
+    /**
+     * Bias adaptation
+     *
+     * @param int     $delta
+     * @param int     $numPoints
+     * @param boolean $firstTime
+     *
+     * @return int
+     */
+    protected function adapt($delta, $numPoints, $firstTime)
+    {
+        $offset = 0;
+        $delta  = $firstTime ? floor($delta / static::DAMP) : $delta >> 1;
+        $delta += floor($delta / $numPoints);
+
+        $tmp = static::BASE - static::TMIN;
+        for (; $delta > $tmp * static::TMAX >> 1; $offset += static::BASE) {
+            $delta = floor($delta / $tmp);
+        }
+
+        return floor($offset + ($tmp + 1) * $delta / ($delta + static::SKEW));
+    }
+
+    /**
+     * Decode a punycode encoded hostname label
+     *
+     * @param string $input the punycode encoded label
+     *
+     * @return string|false Unicode hostname
+     */
+    protected function decodeString($input)
+    {
+        $output = array();
+        $pos    = strrpos($input, static::DELIMITER);
+        if ($pos !== false) {
+            $output = str_split(substr($input, 0, $pos++));
+        }
+        $pos = (int) $pos;
+        $outputLength = count($output);
+        $inputLength  = strlen($input);
+        $n    = static::INITIAL_N;
+        $i    = 0;
+        $bias = static::INITIAL_BIAS;
+        while ($pos < $inputLength) {
+            for ($oldi = $i, $w = 1, $k = static::BASE;; $k += static::BASE) {
+                if ($pos >= $inputLength) {
+                    return false;
+                }
+                $digit = static::$decodeTable[$input[$pos++]];
+                $i    += $digit * $w;
+                $t     = $this->calculateThreshold($k, $bias);
+                if ($digit < $t) {
+                    break;
+                }
+                $w    *= (static::BASE - $t);
+            }
+            $bias = $this->adapt($i - $oldi, ++$outputLength, $oldi === 0);
+            $n    = $n + floor($i / $outputLength);
+            $i   %= $outputLength;
+            $code = $this->codePointToChar($n);
+            if (!mb_check_encoding($code, $this->encoding)) {
+                return false;
+            }
+            $output = array_merge(array_slice($output, 0, $i), [$code], array_slice($output, $i));
+            $i++;
+        }
+
+        return implode('', $output);
     }
 }

--- a/src/PunycodeException.php
+++ b/src/PunycodeException.php
@@ -1,0 +1,9 @@
+<?php
+namespace TrueBV;
+
+use InvalidArgumentException;
+
+class PunycodeException extends InvalidArgumentException
+{
+
+}

--- a/tests/PunycodeTest.php
+++ b/tests/PunycodeTest.php
@@ -13,9 +13,8 @@ class PunycodeTest extends \PHPUnit_Framework_TestCase
      */
     public function testEncode($decoded, $encoded)
     {
-        $Punycode = new Punycode();
-        $result = $Punycode->encode($decoded);
-        $this->assertEquals($encoded, $result);
+        $punycode = new Punycode();
+        $this->assertSame($encoded, $punycode->encode($decoded));
     }
 
     /**
@@ -27,9 +26,8 @@ class PunycodeTest extends \PHPUnit_Framework_TestCase
      */
     public function testDecode($decoded, $encoded)
     {
-        $Punycode = new Punycode();
-        $result = $Punycode->decode($encoded);
-        $this->assertEquals($decoded, $result);
+        $punycode = new Punycode();
+        $this->assertSame($decoded, $punycode->decode($encoded));
     }
 
     /**
@@ -126,14 +124,32 @@ class PunycodeTest extends \PHPUnit_Framework_TestCase
                 '127.0.0.1',
                 '127.0.0.1'
             ),
-            array(
-                '例子.xn--1',
-                'xn--fsqu00a.xn--1'
-            ),
-            array(
-                '例子.xn--g6w131251d',
-                'xn--fsqu00a.xn--g6w131251d',
-            ),
+        );
+    }
+
+    public function testReturnNotDecodeLabel()
+    {
+        $expected = 'xn--£coco';
+        $punycode = new Punycode();
+        $this->assertSame($expected, $punycode->decode($expected));
+    }
+
+    /**
+     * @param $label
+     * @dataProvider invalidDecodedLabelProvider
+     * @expectedException TrueBV\PunycodeException
+     */
+    public function testInvalidDecodeLabel($label)
+    {
+        $punycode = new Punycode();
+        $punycode->decode($label);
+    }
+
+    public function invalidDecodedLabelProvider()
+    {
+        return array(
+            'invalid label' => array('xn--fsqu00a.xn--1'),
+            'invalid codePoint' => array('xn--fsqu00a.xn--g6w131251d'),
         );
     }
 }

--- a/tests/PunycodeTest.php
+++ b/tests/PunycodeTest.php
@@ -118,6 +118,22 @@ class PunycodeTest extends \PHPUnit_Framework_TestCase
                 'gwóźdź.pl',
                 'xn--gwd-hna98db.pl',
             ),
+            array(
+                '[::1]',
+                '[::1]'
+            ),
+            array(
+                '127.0.0.1',
+                '127.0.0.1'
+            ),
+            array(
+                '例子.xn--1',
+                'xn--fsqu00a.xn--1'
+            ),
+            array(
+                '例子.xn--g6w131251d',
+                'xn--fsqu00a.xn--g6w131251d',
+            ),
         );
     }
 }


### PR DESCRIPTION
When an invalid IDN is submitted the class issue a PHP Notice or an ErrorException.
The library algorithm is updated to return the submitted host label unchanged
in case of malformed or invalid label instead. (The error was encountered/reported in [League\Url](https://github.com/thephpleague/url/issues/73)) 

- `Punycode::decodeLabel` and `Punycode::encodeLabel` have been made public. 
- The PHPUnit test has been updated with new tests 
- The Phpunit.xml.dist has been updated to view to code coverage locally
- The composer.json file has been update for the PHPUnit requirement

The `Punycode::decodeLabel` is equivalent to PHP's `idn_to_utf8` and  is equivalent to PHP's `idn_to_ascii`. That's why I still think they should be made public to improve the class usability and testing. In fact, this is how I was able to understand the bug.