### PR TITLE
Fixed composer issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,5 @@
 {
 	"name": "true/punycode",
-	"version": "2.0.0",
-	"type": "library",
 	"description": "A Bootstring encoding of Unicode for Internationalized Domain Names in Applications (IDNA)",
 	"keywords": ["IDNA", "punycode"],
 	"homepage": "https://github.com/true/php-punycode",


### PR DESCRIPTION
The "version" should NEVER be included in composer.json files. It can cause conflicts because as soon as your push any kind of change after the 2.0.0 release, you're redefining that as 2.0.0 as well as the tag.

The library thing doesn't need to be there because that's a default anyway.